### PR TITLE
Improve safe-area handling for headers and nav

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -19,6 +19,12 @@ nav {
 header.navbar {
   height: calc(4rem + env(safe-area-inset-top));
   padding-top: env(safe-area-inset-top);
+  background: linear-gradient(
+    to bottom,
+    rgba(var(--bs-light-rgb), 0.75) 0,
+    rgba(var(--bs-light-rgb), 1) env(safe-area-inset-top)
+  );
+  backdrop-filter: saturate(180%) blur(20px);
 }
 
 .app-content {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,7 @@
 nav {
   font-size: 0.8rem;
-  height: 4rem;
+  height: calc(4rem + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
   .nav-link {
     padding: 0.25rem 0.25rem;
     min-width: 0;
@@ -15,14 +16,19 @@ nav {
   }
 }
 
+header.navbar {
+  height: calc(4rem + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
+}
+
 .app-content {
-  padding-bottom: 4rem; // space for bottom nav
+  padding-bottom: calc(4rem + env(safe-area-inset-bottom)); // space for bottom nav
 }
 
 .has-header {
-  padding-top: 4rem; // space for fixed header
+  padding-top: calc(4rem + env(safe-area-inset-top)); // space for fixed header
 }
 
 .no-header {
-  padding-top: 0;
+  padding-top: env(safe-area-inset-top);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Bumper Plates</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">


### PR DESCRIPTION
## Summary
- adjust title bar and tab bar to account for safe area insets
- update viewport meta tag for iPhone notch support

## Testing
- `npm test -- --watch=false` *(fails: No Chrome binary)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68842ccfdccc8325b223efad7d76d9a6