### PR TITLE
Handle bottom safe area on mobile

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,9 @@
 nav {
   font-size: 0.8rem;
-  height: 4rem;
+  height: calc(4rem + constant(safe-area-inset-bottom));
+  height: calc(4rem + env(safe-area-inset-bottom));
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
   .nav-link {
     padding: 0.25rem 0.25rem;
     min-width: 0;
@@ -16,7 +19,8 @@ nav {
 }
 
 .app-content {
-  padding-bottom: 4rem; // space for bottom nav
+  padding-bottom: calc(4rem + constant(safe-area-inset-bottom)); // space for bottom nav
+  padding-bottom: calc(4rem + env(safe-area-inset-bottom));
 }
 
 .has-header {

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Bumper Plates</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">


### PR DESCRIPTION
## Summary
- adjust meta viewport to support `viewport-fit=cover`
- extend bottom navigation styles with safe area insets

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884337c3ae4832591ef84e313ec31a0