### PR TITLE
Add build version footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bumper-plates-front",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -7,5 +7,6 @@
       <h1>{{ title }}</h1>
       <p>{{ subtitle }}</p>
     </div>
-  </div>
+</div>
+  <p class="version-text">Desarrollado en 🇨🇱. Versión {{ version }}.</p>
 </main>

--- a/src/app/features/home/home.component.scss
+++ b/src/app/features/home/home.component.scss
@@ -56,13 +56,13 @@ p {
 
 main {
   width: 100%;
-  min-height: 100%;
+  min-height: calc(100dvh - 4rem);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
   padding: 1rem;
   box-sizing: inherit;
-  position: relative;
 }
 
 .angular-logo {
@@ -91,4 +91,10 @@ main {
     width: 256px;
     height: 256px;
   }
+}
+
+.version-text {
+  margin-bottom: 0.5rem;
+  color: var(--gray-700);
+  font-size: 0.875rem;
 }

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
+import packageJson from '../../../../package.json';
 
 @Component({
   selector: 'app-home',
@@ -10,4 +11,6 @@ import { Component } from '@angular/core';
 export class HomeComponent {
   title = 'Bienvenido a Bumper Plates';
   subtitle = 'Tu app para ayudarte a levantar mejor 😉';
+  /** Current application version. */
+  readonly version: string = (packageJson as { version: string }).version;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary
- show app version at bottom of home screen
- style home screen to stretch full height
- import build version from `package.json`
- enable `resolveJsonModule` support in TypeScript
- bump minor version to 0.7.0

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884471b5074832588c3b8e778dde262